### PR TITLE
fixed TextStatus

### DIFF
--- a/static/js/bitcoinbeacon_create.js
+++ b/static/js/bitcoinbeacon_create.js
@@ -656,7 +656,7 @@ function getFutureBlockNum(resultsDateVal, resultsTimeVal)
 			})
 		}).fail(function(retargetTextStatus, error)
 		{
-			console.log("Error: " + textStatus + " " + error);
+			console.log("Error: " + retargetTextStatus + " " + error);
 		});
 
 	}).fail(function(textStatus, error)


### PR DESCRIPTION
Hi. I'm playing with your code. And I found an incorrect variable name in error logging function in bitcoinbeacon_create.js. Function receives first argument as retargetTextStatus variable, but console.log tries to print TextStatus variable instead.